### PR TITLE
Secure S3 Access

### DIFF
--- a/esimsrouter/esims_router/aws_connector.py
+++ b/esimsrouter/esims_router/aws_connector.py
@@ -28,7 +28,14 @@ class S3Connector:
         """
         self.s3.put_object(Bucket=self.bucket, Key=key, Body=data)
         logger.info("Data loaded to S3: %s", key)
-        return aws_c.OBJECT_URL.format(self.bucket, key)
+        return self.s3.generate_presigned_url(
+            ClientMethod=aws_c.CLIENT_METHOD,
+            Params={
+                aws_c.BUCKET: self.bucket,
+                aws_c.KEY: key,
+            },
+            ExpiresIn=600,
+        )
 
 
 class SQSConnector:

--- a/esimsrouter/esims_router/constants.py
+++ b/esimsrouter/esims_router/constants.py
@@ -28,8 +28,10 @@ class AWSConst:
     S3 = "s3"
     SQS = "sqs"
 
-    # URL
-    OBJECT_URL = "https://{0}.s3.amazonaws.com/{1}"
+    # URL Generation
+    CLIENT_METHOD = "get_object"
+    BUCKET = "Bucket"
+    KEY = "Key"
 
 
 class AirTableConst:


### PR DESCRIPTION
### What does this change?

Secure access to S3 resources.

### What was wrong?

S3 Bucket was set as public to allow for AirTable to download Generated QR Codes. That was insecure.

### How does this fix it?

- Closed public connection to the S3 bucket to secure it.
- Entertains presigned urls generation temporarly to allow AirTable to use it in uploading content.