### PR TITLE
Monitor state using parameter storage

### DIFF
--- a/esimsrouter/esims_router/constants.py
+++ b/esimsrouter/esims_router/constants.py
@@ -26,12 +26,22 @@ class AWSConst:
 
     # Services
     S3 = "s3"
-    SQS = "sqs"
+    SSM = "ssm"
 
     # URL Generation
     CLIENT_METHOD = "get_object"
     BUCKET = "Bucket"
     KEY = "Key"
+
+    # SSM
+    PARAMETER = "Parameter"
+    VALUE = "Value"
+    PARAMETER_TYPE = "String"
+
+    # Lambda State
+    STATE_KEY = "ESIMS_LAMBDA_STATE"
+    ON = "ON"
+    OFF = "OFF"
 
 
 class AirTableConst:

--- a/esimsrouter/esims_router/main.py
+++ b/esimsrouter/esims_router/main.py
@@ -8,7 +8,7 @@ import time
 from esims_router.logger import logger
 from esims_router.constants import RouterConst as r_c
 from esims_router.dropbox_connector import DropboxConnector
-from esims_router.aws_connector import S3Connector, SQSConnector
+from esims_router.aws_connector import S3Connector, SSMConnector
 from esims_router.airtable_connector import AirTableConnector
 
 
@@ -58,11 +58,14 @@ def handler(event: dict, context: dict) -> None:
     Raises:
         Exception: if main service failed.
     """
-    try:
-        main()
-        logger.info("Passing on to the next iteration...")
-        SQSConnector().publish({"invoke": "lambda"})
-        time.sleep(10)
-    except Exception as exc:
-        logger.error("Main Service Driver Error: %s", exc)
-        raise exc
+    ssm = SSMConnector()
+    if ssm.get_state():
+        try:
+            ssm.set_state()
+            main()
+            ssm.reset_state()
+        except Exception as exc:
+            logger.error("Main Service Driver Error: %s", exc)
+            raise exc
+    else:
+        logger.info("Esims Router already running. Skipping ...")


### PR DESCRIPTION
### What does this change?

Monitor Lambda State through a parameter.

### What was wrong?

AWS was dropping Lambda becuase it was recursive being tirggered by SQS.

### How does this fix it?

- Capture lambda state in an AWS parameter.
- Check parameter status at the initiation of the service.
- Skip if State is ON
- Set State at the beginning of the run.
- Reset State at the end of the run.
