### PR TITLE
Array of Ids

### DIFF
--- a/esimsrouter/esims_router/airtable_connector.py
+++ b/esimsrouter/esims_router/airtable_connector.py
@@ -47,7 +47,7 @@ class AirTableConnector:
         """
         try:
             records = [
-                {air_c.SIM: sim, air_c.ATTACHMENT: [attachment(url)]}
+                {air_c.SIM: [sim], air_c.ATTACHMENT: [attachment(url)]}
                 for url in urls
             ]
             for batch in self.batch_records(records):

--- a/esimsrouter/esims_router/main.py
+++ b/esimsrouter/esims_router/main.py
@@ -94,6 +94,7 @@ def handler(event: dict, context: dict) -> None:
             state.reset_state()
         except Exception as exc:
             logger.error("Main Service Driver Error: %s", exc)
+            state.reset_state()
             raise exc
     else:
         logger.info("Esims Router already running. Skipping ...")


### PR DESCRIPTION
### What does this change?

Store sim as an array of strings

### What was wrong?

- Airtable expecting array of Ids
- Lambda was not resetting state in case of failure

### How does this fix it?

- set sim as an array
- reset state in case of failure