### PR TITLE
Ingest Esims

### DIFF
--- a/ingestesims/constraints.txt
+++ b/ingestesims/constraints.txt
@@ -6,9 +6,9 @@
 #
 annotated-types==0.6.0
     # via pydantic
-boto3==1.29.6
+boto3==1.33.0
     # via esimslib
-botocore==1.32.6
+botocore==1.33.0
     # via
     #   boto3
     #   s3transfer
@@ -26,6 +26,12 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+numpy==1.24.4
+    # via
+    #   -r requirements.in
+    #   opencv-python-headless
+opencv-python-headless==4.8.1.78
+    # via -r requirements.in
 ply==3.11
     # via stone
 pyairtable==2.2.0
@@ -38,9 +44,10 @@ python-dateutil==2.8.2
     # via botocore
 requests==2.31.0
     # via
+    #   -r requirements.in
     #   dropbox
     #   pyairtable
-s3transfer==0.7.0
+s3transfer==0.8.0
     # via boto3
 six==1.16.0
     # via

--- a/ingestesims/ingest_esims/constants.py
+++ b/ingestesims/ingest_esims/constants.py
@@ -8,3 +8,6 @@ class IngestSimsConst:
 
     # Root Folder
     DBX_PATH = "/ESims for Gaza/Fresh Sims to Load in Airtable/{}"
+
+    # Qr Code Attachment Key
+    URL = "url"

--- a/ingestesims/ingest_esims/constants.py
+++ b/ingestesims/ingest_esims/constants.py
@@ -6,14 +6,5 @@
 class IngestSimsConst:
     """Ingest Sims Defines"""
 
-    # Table Name
-    TABLE_NAME = "ESim Donations"
-
-    # Fields
-    TARGET_FOLDER = "eSIM Provider Name"
-    ATTACHMENTS = "QR Codes"
-    FILE_NAME = "filename"
-    URL = "url"
-
     # Root Folder
     DBX_PATH = "/ESims for Gaza/Fresh Sims to Load in Airtable/{}"

--- a/ingestesims/ingest_esims/main.py
+++ b/ingestesims/ingest_esims/main.py
@@ -7,25 +7,25 @@ from esimslib.airtable import Donations
 from ingest_esims.constants import IngestSimsConst as in_c
 from ingest_esims.qr_code_detector import QRCodeDetector
 
-# def consolidate_sim_provider(esims: list) -> dict:
-#     """Consolidate all esims for the same provider.
 
-#     Args:
-#         esims (list): List of esims.
-#             [{folder_name}, {list of attachments}]
+def consolidate_by_provider(records: list) -> dict:
+    """Consolidate all esims for the same provider.
 
-#     Returns:
-#         dict: Consolidated esims.
-#             {provider_name: [urls]}
+    Args:
+        records (list): List of Donations Records.
 
-#     """
-#     esims_by_provider = {}
-#     for esim in esims:
-#         provider_name = esim.get(in_c.TARGET_FOLDER)
-#         if not provider_name in esims_by_provider:
-#             esims_by_provider[provider_name] = []
-#         esims_by_provider[provider_name].extend(esim.get(in_c.ATTACHMENTS))
-#     return esims_by_provider
+    Returns:
+        dict: Consolidated esims.
+            {provider_name: [urls]}
+
+    """
+    esims_by_provider = {}
+    for record in records:
+        provider_name = record.esim_provider[0].name
+        if not provider_name in esims_by_provider:
+            esims_by_provider[provider_name] = []
+        esims_by_provider[provider_name].extend(record.extract_urls())
+    return esims_by_provider
 
 
 def load_data_to_dbx(esims: dict) -> None:
@@ -78,8 +78,8 @@ def main() -> None:
     valid_records = [record for record in records if record.qr_codes]
     logger.info("Validated Donated eSIMs records: %s", len(valid_records))
 
-    # esims_by_provider = consolidate_sim_provider(esims)
-    # load_data_to_dbx(esims_by_provider)
+    esims_by_provider = consolidate_by_provider(valid_records)
+    load_data_to_dbx(esims_by_provider)
     # # TODO: Update status in AirTable
 
 

--- a/ingestesims/ingest_esims/qr_code_detector.py
+++ b/ingestesims/ingest_esims/qr_code_detector.py
@@ -1,0 +1,46 @@
+"""QR Code Detector"""
+
+import requests
+import cv2
+import numpy as np
+
+from esimslib.util.logger import logger
+
+# pylint: disable=no-member
+
+
+class QRCodeDetector:
+    """QR Code Detector"""
+
+    def __init__(self, url: str) -> None:
+        """QR Code Detector
+
+        Args:
+            url (str): Image URL to detect QR Code.
+        """
+        self.url = url
+
+    def _read_image(self) -> np.ndarray:
+        """Format Image from url
+
+        Returns:
+            np.ndarry: Image array from URL
+        """
+        try:
+            response = requests.get(self.url, timeout=30)
+        except requests.exceptions.RequestException as exc:
+            logger.error("Failed to read image: %s", exc)
+            raise exc
+        image = np.asarray(bytearray(response.content), dtype="uint8")
+        image = cv2.imdecode(image, cv2.IMREAD_COLOR)
+        return image
+
+    def detect(self) -> bool:
+        """Detect QR Code
+
+        Returns:
+            bool: True if QR Codel is detected, False otherwise.
+        """
+        detector = cv2.QRCodeDetector()
+        detected, _ = detector.detect(self._read_image())
+        return detected

--- a/ingestesims/requirements.in
+++ b/ingestesims/requirements.in
@@ -1,1 +1,4 @@
+opencv-python-headless
+numpy
+requests
 -e file:../lib

--- a/ingestesims/requirements.txt
+++ b/ingestesims/requirements.txt
@@ -8,9 +8,9 @@
     # via -r requirements.in
 annotated-types==0.6.0
     # via pydantic
-boto3==1.29.6
+boto3==1.33.0
     # via esimslib
-botocore==1.32.6
+botocore==1.33.0
     # via
     #   boto3
     #   s3transfer
@@ -28,6 +28,12 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+numpy==1.24.4
+    # via
+    #   -r requirements.in
+    #   opencv-python-headless
+opencv-python-headless==4.8.1.78
+    # via -r requirements.in
 ply==3.11
     # via stone
 pyairtable==2.2.0
@@ -40,9 +46,10 @@ python-dateutil==2.8.2
     # via botocore
 requests==2.31.0
     # via
+    #   -r requirements.in
     #   dropbox
     #   pyairtable
-s3transfer==0.7.0
+s3transfer==0.8.0
     # via boto3
 six==1.16.0
     # via

--- a/ingestesims/test-requirements.txt
+++ b/ingestesims/test-requirements.txt
@@ -12,11 +12,11 @@ annotated-types==0.6.0
     # via
     #   -c constraints.txt
     #   pydantic
-boto3==1.29.6
+boto3==1.33.0
     # via
     #   -c constraints.txt
     #   esimslib
-botocore==1.32.6
+botocore==1.33.0
     # via
     #   -c constraints.txt
     #   boto3
@@ -46,6 +46,15 @@ jmespath==1.0.1
     #   -c constraints.txt
     #   boto3
     #   botocore
+numpy==1.24.4
+    # via
+    #   -c constraints.txt
+    #   -r requirements.in
+    #   opencv-python-headless
+opencv-python-headless==4.8.1.78
+    # via
+    #   -c constraints.txt
+    #   -r requirements.in
 ply==3.11
     # via
     #   -c constraints.txt
@@ -69,9 +78,10 @@ python-dateutil==2.8.2
 requests==2.31.0
     # via
     #   -c constraints.txt
+    #   -r requirements.in
     #   dropbox
     #   pyairtable
-s3transfer==0.7.0
+s3transfer==0.8.0
     # via
     #   -c constraints.txt
     #   boto3

--- a/lib/esimslib/airtable/constants.py
+++ b/lib/esimslib/airtable/constants.py
@@ -34,6 +34,12 @@ class DonationsModelConst:
     QR_CODE = "QR Codes"
     IN_USE_FLAG = "QR Code In Use"
 
+    # QR Codes Keys
+    TYPE = "type"
+    FILENAME = "filename"
+    URL = "url"
+    IMAGE = "image"
+
 
 class AttachmentModelConst:
     """Attachment Model Defines"""

--- a/lib/esimslib/airtable/constants.py
+++ b/lib/esimslib/airtable/constants.py
@@ -33,12 +33,18 @@ class DonationsModelConst:
     ESIM_PROVIDER = "eSIM Provider"
     QR_CODE = "QR Codes"
     IN_USE_FLAG = "QR Code In Use"
+    DONOR_ERROR = "Donor Error"
 
     # QR Codes Keys
     TYPE = "type"
     FILENAME = "filename"
     URL = "url"
+
+    # Accepted Types
     IMAGE = "image"
+
+    # Set Values
+    YES = "Yes"
 
 
 class AttachmentModelConst:

--- a/lib/esimslib/airtable/models.py
+++ b/lib/esimslib/airtable/models.py
@@ -46,6 +46,7 @@ class Donations(Model):
     esim_provider = fields.LinkField(don_c.ESIM_PROVIDER, Providers)
     qr_codes = fields.AttachmentsField(don_c.QR_CODE)
     in_use_flag = fields.SelectField(don_c.IN_USE_FLAG)
+    donor_error = fields.CheckboxField(don_c.DONOR_ERROR)
 
     @classmethod
     def fetch_all(cls) -> list:
@@ -82,6 +83,14 @@ class Donations(Model):
         for attachment_ in self.qr_codes:
             urls.append(attachment_.get(don_c.URL))
         return urls
+
+    def set_in_use(self) -> None:
+        """Set in use Flag to Yes"""
+        self.in_use_flag = don_c.YES
+
+    def set_donor_error(self) -> None:
+        """Set Donor Error to True"""
+        self.donor_error = True
 
     class Meta:
         """Config subClass"""

--- a/lib/esimslib/airtable/models.py
+++ b/lib/esimslib/airtable/models.py
@@ -72,7 +72,7 @@ class Donations(Model):
             else:
                 self.qr_codes.remove(attachment_)
 
-    def extract_url(self) -> list:
+    def extract_urls(self) -> list:
         """Extract URL from attachment.
 
         Returns:

--- a/lib/esimslib/airtable/models.py
+++ b/lib/esimslib/airtable/models.py
@@ -56,6 +56,33 @@ class Donations(Model):
         """
         return cls.all(view=air_c.DEFAULT_VIEW)
 
+    def check_attachment_type(self) -> None:
+        """Check if attachment type is image."""
+        for attachment_ in self.qr_codes:
+            if not don_c.IMAGE in attachment_.get(don_c.TYPE):
+                self.qr_codes.remove(attachment_)
+
+    def remove_duplicate_files(self) -> None:
+        """Remove Duplicate file names"""
+        filenames = set()
+        for attachment_ in self.qr_codes:
+            filename = attachment_.get(don_c.FILENAME)
+            if not filename in filenames:
+                filenames.add(filename)
+            else:
+                self.qr_codes.remove(attachment_)
+
+    def extract_url(self) -> list:
+        """Extract URL from attachment.
+
+        Returns:
+            list: list of URLs.
+        """
+        urls = []
+        for attachment_ in self.qr_codes:
+            urls.append(attachment_.get(don_c.URL))
+        return urls
+
     class Meta:
         """Config subClass"""
 


### PR DESCRIPTION
### What does this change?

Implement Ingest eSIMs

### What was wrong?

New Development

### How does this fix it?

- ingest esims now uses airtable models.
- Validate records on the following criteria:
  * Validate Attachment is of Image type
  * Validate Attachments do not contain the same named files.
  * Validate images containing QR codes.
- Update uploaded esims in AirTable to be in-use
- Update erred donations with Donor Error Flag. 