### PR TITLE
Ingest Into AirTable

### DIFF
--- a/esimsrouter/esims_router/main.py
+++ b/esimsrouter/esims_router/main.py
@@ -41,6 +41,23 @@ class LambdaState:
         logger.info("Lambda Status Reset.")
 
 
+def load_data_to_airtable(provider_id: str, urls: list) -> None:
+    """Load data to AirTable
+
+    Args:
+        provider_id (str): Provider ID.
+        urls (list): List of QR Codes URLs.
+    """
+    attachments = [
+        Attachments(
+            esim_provider=Attachments.format_esim_provider_field(provider_id),
+            attachment=Attachments.format_attachment_field(url),
+        )
+        for url in urls
+    ]
+    Attachments.load_records(attachments)
+
+
 def main() -> None:
     """Main Service Driver"""
     logger.info("Starting e-sims transport service")
@@ -71,7 +88,7 @@ def main() -> None:
         logger.info("S3 Loaded Sims: %s", len(urls))
 
         # upload to AirTable
-        Attachments.load_attachments(record.id, urls)
+        load_data_to_airtable(record.id, urls)
         logger.info("Uploaded to AirTable: %s", record.name)
 
         # delete from Dropbox

--- a/ingestesims/ingest_esims/main.py
+++ b/ingestesims/ingest_esims/main.py
@@ -65,7 +65,7 @@ def load_data_to_airtable(valid_records: list) -> int:
             [
                 Attachments(
                     esim_provider=record.esim_provider,
-                    attachment=Attachments.set_attachment_field(url),
+                    attachment=Attachments.format_attachment_field(url),
                     donor=[record],
                 )
                 for url in urls

--- a/lib/esimslib/airtable/constants.py
+++ b/lib/esimslib/airtable/constants.py
@@ -49,4 +49,5 @@ class AttachmentModelConst:
 
     # Table Variables
     ESIM_PROVIDER = "eSIM Provider"
+    DONOR = "Linked Donor"
     ATTACHMENT = "Attachments"

--- a/lib/esimslib/airtable/models.py
+++ b/lib/esimslib/airtable/models.py
@@ -1,7 +1,6 @@
 """AirTable Connector"""
 
 import os
-from typing import Generator
 
 from pyairtable.utils import attachment
 from pyairtable.orm import Model, fields


### PR DESCRIPTION
### What does this change?

Ingest Donations Into AirTable

### What was wrong?

- Errored donations were missing attachements in notifications and it is needed for auditing.
- There was a need to link donated eSIMs to their donnors.
- AirTable SDK takes care of batching when saving.


### How does this fix it?

- Switched to load esim donations directly to AirTable instead of using Dropbox.
- Kept original copy of the attachments to update status on to reserve invalid attachments for auditing.
- Removed batching method.