### PR TITLE
Store Hashed QR Code info

### DIFF
--- a/ingestesims/ingest_esims/main.py
+++ b/ingestesims/ingest_esims/main.py
@@ -67,8 +67,9 @@ def load_data_to_airtable(valid_records: list) -> int:
                     esim_provider=record.esim_provider,
                     attachment=Attachments.format_attachment_field(url),
                     donor=[record],
+                    qr_sha=sha,
                 )
-                for url in urls
+                for sha, url in urls.items()
             ]
         )
     Attachments.load_records(attachments)

--- a/ingestesims/ingest_esims/validate_donation.py
+++ b/ingestesims/ingest_esims/validate_donation.py
@@ -1,5 +1,9 @@
 """Validate Donation Class"""
 
+import hashlib
+
+from esimslib.airtable.constants import DonationsModelConst as don_c
+
 from ingest_esims.constants import ValidateDonationConst as vd_c
 from ingest_esims.qr_code_detector import QRCodeDetector
 
@@ -44,6 +48,13 @@ class ValidateDonation:
             detector = QRCodeDetector(attachment_.get(vd_c.URL))
             if detector.detect():
                 if any(v in detector.qr_code for v in self.qr_text):
+                    attachment_.update(
+                        {
+                            don_c.SHA: hashlib.sha256(
+                                detector.qr_code.encode(vd_c.UTF8)
+                            ).hexdigest()
+                        }
+                    )
                     valid_qr_codes.append(attachment_)
                 else:
                     self.record.provider_mismatch = True

--- a/lib/esimslib/airtable/constants.py
+++ b/lib/esimslib/airtable/constants.py
@@ -41,6 +41,7 @@ class DonationsModelConst:
 
     # QR Codes Keys
     URL = "url"
+    SHA = "sha"
 
     # Set Values
     YES = "Yes"
@@ -55,3 +56,4 @@ class AttachmentModelConst:
     ESIM_PROVIDER = "eSIM Provider"
     DONOR = "Linked Donor"
     ATTACHMENT = "Attachments"
+    QR_SHA = "QR SHA"

--- a/lib/esimslib/airtable/models.py
+++ b/lib/esimslib/airtable/models.py
@@ -60,15 +60,15 @@ class Donations(Model):
         """
         return cls.all(view=air_c.DEFAULT_VIEW)
 
-    def extract_urls(self) -> list:
-        """Extract URL from attachment.
+    def extract_urls(self) -> dict:
+        """Extract SHA: URL from attachment.
 
         Returns:
-            list: list of URLs.
+            dict: {SHA: URL}.
         """
-        urls = []
+        urls = {}
         for attachment_ in self.qr_codes:
-            urls.append(attachment_.get(don_c.URL))
+            urls[attachment_.get(don_c.SHA)] = attachment_.get(don_c.URL)
         return urls
 
     def set_in_use(self) -> None:
@@ -93,6 +93,7 @@ class Attachments(Model):
     esim_provider = fields.LinkField(att_c.ESIM_PROVIDER, Providers)
     attachment = fields.AttachmentsField(att_c.ATTACHMENT)
     donor = fields.LinkField(att_c.DONOR, Donations)
+    qr_sha = fields.TextField(att_c.QR_SHA)
 
     @classmethod
     def load_records(cls, records: list) -> None:


### PR DESCRIPTION
### What does this change?

Capture and store hashed version of the QR Code info.

### What was wrong?

We were getting duplicate donation submissions.

### How does this fix it?

Capture the hashed QR code info to Airtable to compare submissions and remove duplicates.