### PR TITLE
Notify Donors of Duplication

### DIFF
--- a/deduplicate/deduplicate/constants.py
+++ b/deduplicate/deduplicate/constants.py
@@ -1,0 +1,9 @@
+"""Duplicate module constants"""
+
+# pylint: disable=too-few-public-methods
+
+
+class DuplicateConst:
+    """Duplicate module constants."""
+
+    DEFAULT_EMAIL = "IamDifferent"

--- a/deduplicate/deduplicate/main.py
+++ b/deduplicate/deduplicate/main.py
@@ -3,6 +3,8 @@
 from esimslib.util import logger
 from esimslib.airtable import Attachments, Donations
 
+from deduplicate.constants import DuplicateConst as d_c
+
 
 def combine_duplicated_records(records: list) -> dict:
     """Combine duplicated records
@@ -33,6 +35,7 @@ def delete_duplicate(records: list) -> None:
     # if original record misses the donor.
     if len(records) == 1:
         records.append(records[0])
+        records[0].donor[0].email = d_c.DEFAULT_EMAIL
     original, duplicates = records[0], records[1:]
     # check if submissions from different donors
     donors = [

--- a/deduplicate/deduplicate/main.py
+++ b/deduplicate/deduplicate/main.py
@@ -1,7 +1,7 @@
 """Deduplicate Esims Linked"""
 
 from esimslib.util import logger
-from esimslib.airtable import Attachments
+from esimslib.airtable import Attachments, Donations
 
 
 def combine_duplicated_records(records: list) -> dict:
@@ -28,10 +28,27 @@ def delete_duplicate(records: list) -> None:
     Args:
         records (list): list of records.
     """
+    # sort records chronologically
     records.sort(key=lambda record: record.order_id)
+    # if original record misses the donor.
     if len(records) == 1:
         records.append(records[0])
-    Attachments.batch_delete(records[1:])
+    original, duplicates = records[0], records[1:]
+    # check if submissions from different donors
+    donors = [
+        record.donor[0]
+        for record in duplicates
+        if not (
+            record.donor[0].email.lower() == original.donor[0].email.lower()
+        )
+    ]
+    # delete duplicates
+    Attachments.batch_delete(duplicates)
+    # notify different donors
+    if donors:
+        # pylint: disable=expression-not-assigned
+        [donor.set_duplicate_error() for donor in donors]
+        Donations.batch_save(donors)
 
 
 def main() -> None:

--- a/lib/esimslib/airtable/constants.py
+++ b/lib/esimslib/airtable/constants.py
@@ -38,6 +38,8 @@ class DonationsModelConst:
     INVALID_TYPE = "Invalid Type"
     MISSING_QR = "Missing QR Code"
     PROVIDER_MISMATCH = "Provider Mismatch"
+    EMAIL = "Email"
+    DUPLICATE = "Duplicate"
 
     # QR Codes Keys
     URL = "url"

--- a/lib/esimslib/airtable/models.py
+++ b/lib/esimslib/airtable/models.py
@@ -50,6 +50,8 @@ class Donations(Model):
     invalid_type = fields.CheckboxField(don_c.INVALID_TYPE)
     missing_qr = fields.CheckboxField(don_c.MISSING_QR)
     provider_mismatch = fields.CheckboxField(don_c.PROVIDER_MISMATCH)
+    email = fields.TextField(don_c.EMAIL)
+    duplicate = fields.CheckboxField(don_c.DUPLICATE)
 
     @classmethod
     def fetch_all(cls) -> list:
@@ -78,6 +80,10 @@ class Donations(Model):
     def set_donor_error(self) -> None:
         """Set Donor Error to True"""
         self.donor_error = True
+
+    def set_duplicate_error(self) -> None:
+        """Set Duplicate Error to True"""
+        self.duplicate = True
 
     class Meta:
         """Config subClass"""

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,3 +35,6 @@ ignore_missing_imports = True
 
 [mypy-ingest_esims.*]
 ignore_missing_imports = True
+
+[mypy-deduplicate.*]
+ignore_missing_imports = True


### PR DESCRIPTION
### What does this change?

Set duplicate flag for donors with duplications.

### What was wrong?

Donors of different emails were not notified when their donation was rejected.

### How does this fix it?

- Capture if the duplicate submission came from a different email address from the original one.
- Set the duplicate flag in the donor record.