### PR TITLE
Link Original Donation

### DIFF
--- a/deduplicate/deduplicate/main.py
+++ b/deduplicate/deduplicate/main.py
@@ -49,8 +49,9 @@ def delete_duplicate(records: list) -> None:
     Attachments.batch_delete(duplicates)
     # notify different donors
     if donors:
-        # pylint: disable=expression-not-assigned
-        [donor.set_duplicate_error() for donor in donors]
+        for donor in donors:
+            donor.set_duplicate_error()
+            donor.original = [original.donor[0]]
         Donations.batch_save(donors)
 
 

--- a/deduplicate/deduplicate/main.py
+++ b/deduplicate/deduplicate/main.py
@@ -24,6 +24,23 @@ def combine_duplicated_records(records: list) -> dict:
     return combined_records
 
 
+def _update_duplicate_donation_info(
+    original: Donations, duplicates: list
+) -> None:
+    """Update duplicate donation info
+
+    Args:
+        original (Donations): original record.
+        duplicates (list): list of duplicates.
+    """
+    for duplicate in duplicates:
+        duplicate.set_duplicate_error()
+        duplicate.set_original_donor(original)
+        if not duplicate.email.lower() == original.email.lower():
+            duplicate.set_different_email()
+    Donations.batch_save(duplicates)
+
+
 def delete_duplicate(records: list) -> None:
     """Delete duplicate records
 
@@ -37,22 +54,12 @@ def delete_duplicate(records: list) -> None:
         records.append(records[0])
         records[0].donor[0].email = d_c.DEFAULT_EMAIL
     original, duplicates = records[0], records[1:]
-    # check if submissions from different donors
-    donors = [
-        record.donor[0]
-        for record in duplicates
-        if not (
-            record.donor[0].email.lower() == original.donor[0].email.lower()
-        )
-    ]
     # delete duplicates
     Attachments.batch_delete(duplicates)
-    # notify different donors
-    if donors:
-        for donor in donors:
-            donor.set_duplicate_error()
-            donor.original = [original.donor[0]]
-        Donations.batch_save(donors)
+    # update donation info
+    _update_duplicate_donation_info(
+        original.donor[0], [duplicate.donor[0] for duplicate in duplicates]
+    )
 
 
 def main() -> None:

--- a/lib/esimslib/airtable/constants.py
+++ b/lib/esimslib/airtable/constants.py
@@ -41,6 +41,7 @@ class DonationsModelConst:
     EMAIL = "Email"
     DUPLICATE = "Duplicate"
     ORIGINAL = "Original Donation"
+    DIFF_EMAIL = "Different Email"
 
     # QR Codes Keys
     URL = "url"

--- a/lib/esimslib/airtable/constants.py
+++ b/lib/esimslib/airtable/constants.py
@@ -40,6 +40,7 @@ class DonationsModelConst:
     PROVIDER_MISMATCH = "Provider Mismatch"
     EMAIL = "Email"
     DUPLICATE = "Duplicate"
+    ORIGINAL = "Original Donation"
 
     # QR Codes Keys
     URL = "url"

--- a/lib/esimslib/airtable/models.py
+++ b/lib/esimslib/airtable/models.py
@@ -53,6 +53,7 @@ class Donations(Model):
     email = fields.TextField(don_c.EMAIL)
     duplicate = fields.CheckboxField(don_c.DUPLICATE)
     original = fields.LinkField(don_c.ORIGINAL, "Donations")
+    diff_email = fields.CheckboxField(don_c.DIFF_EMAIL)
 
     @classmethod
     def fetch_all(cls) -> list:
@@ -85,6 +86,18 @@ class Donations(Model):
     def set_duplicate_error(self) -> None:
         """Set Duplicate Error to True"""
         self.duplicate = True
+
+    def set_different_email(self) -> None:
+        """Set Different Email to True"""
+        self.diff_email = True
+
+    def set_original_donor(self, donor: "Donations") -> None:
+        """Set Original Donor
+
+        Args:
+            donor (Donations): Original Donor.
+        """
+        self.original = [donor]
 
     class Meta:
         """Config subClass"""

--- a/lib/esimslib/airtable/models.py
+++ b/lib/esimslib/airtable/models.py
@@ -52,6 +52,7 @@ class Donations(Model):
     provider_mismatch = fields.CheckboxField(don_c.PROVIDER_MISMATCH)
     email = fields.TextField(don_c.EMAIL)
     duplicate = fields.CheckboxField(don_c.DUPLICATE)
+    original = fields.LinkField(don_c.ORIGINAL, "Donations")
 
     @classmethod
     def fetch_all(cls) -> list:


### PR DESCRIPTION
### What does this change?

Link original donation to duplicate donation.

### What was wrong?

Duplicate donation was marked but not linked.

### How does this fix it?

- Added a linked donation field to the donation.
- Capture the original donation and add it to the duplicate donation.
- Differentiate when the duplicate came from a different email for notification support