### PR TITLE
Capture duplicates from stocked eSIMs

### DIFF
--- a/deduplicate/deduplicate/constants.py
+++ b/deduplicate/deduplicate/constants.py
@@ -6,4 +6,4 @@
 class DuplicateConst:
     """Duplicate module constants."""
 
-    DEFAULT_EMAIL = "IamDifferent"
+    MEEDAN = "Meedan"


### PR DESCRIPTION
### What does this change?

Capture duplicates from stocked eSIMs

### What was wrong?

It was found our stocked eSIMs created duplicates either via stocking or when a stocked eSIM is also donated for some reason.

### How does this fix it?

To avoid this duplication, we implemented a mechanism that captures a duplicated eSIM even if stocked, the implementation updates a duplicated donation even if it's original is a stocked eSIM, and keeps the eSIM donation untouched since there are no matched donations for stocked ones.
- The implementation took "Meedan" eSIMs specifically out since this can be overriden.