### PR TITLE
Fix: fix docker files

### DIFF
--- a/deduplicate/Dockerfile
+++ b/deduplicate/Dockerfile
@@ -8,6 +8,12 @@ COPY ./lib ${LAMBDA_TASK_ROOT}/lib
 # Set Working Directory
 WORKDIR ${LAMBDA_TASK_ROOT}/deduplicate
 
+# Install dependencies
+RUN yum -y update \
+    && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    && yum makecache \
+    && yum -y install zbar
+
 # Install requirements
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m ensurepip

--- a/esimsrouter/Dockerfile
+++ b/esimsrouter/Dockerfile
@@ -8,6 +8,12 @@ COPY ./lib ${LAMBDA_TASK_ROOT}/lib
 # Set Working Directory
 WORKDIR ${LAMBDA_TASK_ROOT}/esimsrouter
 
+# Install dependencies
+RUN yum -y update \
+    && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    && yum makecache \
+    && yum -y install zbar
+
 # Install requirements
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m ensurepip

--- a/refreshdropbox/Dockerfile
+++ b/refreshdropbox/Dockerfile
@@ -8,6 +8,12 @@ COPY ./lib ${LAMBDA_TASK_ROOT}/lib
 # Set Working Directory
 WORKDIR ${LAMBDA_TASK_ROOT}/refreshdropbox
 
+# Install dependencies
+RUN yum -y update \
+    && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    && yum makecache \
+    && yum -y install zbar
+
 # Install requirements
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m ensurepip


### PR DESCRIPTION
### What does this change?

Fix all docker files.

### What was wrong?

QR Detector opencv requires certain packages in any docker image it is running in.

### How does this fix it?

Added the packages for all docker files now that QR Detector is a shared library.