### PR TITLE
Fix: Stocking Error Notification

### DIFF
--- a/esimsrouter/esims_router/main.py
+++ b/esimsrouter/esims_router/main.py
@@ -174,9 +174,11 @@ def main() -> None:
             )
 
         # Check if invalid
-        invalid_list = list(set(path_list) - set(valid_list))
+        invalid_list = bool(set(path_list) - set(valid_list))
         if invalid_list:
             record.set_stock_err()
+        else:
+            record.reset_stock_err()
         logger.info("Esims Uploaded Successfully: %s", record.name)
 
 

--- a/lib/esimslib/airtable/models.py
+++ b/lib/esimslib/airtable/models.py
@@ -35,7 +35,13 @@ class Providers(Model):
 
     def set_stock_err(self) -> None:
         """Set stocking error flag."""
-        Providers(id=self.id, stock_err=True).save()
+        if not self.stock_err:
+            Providers(id=self.id, stock_err=True).save()
+
+    def reset_stock_err(self) -> None:
+        """Reset stocking error flag."""
+        if self.stock_err:
+            Providers(id=self.id, stock_err=False).save()
 
     class Meta:
         """Config subClass"""


### PR DESCRIPTION
### What does this change?

Limit notification to status change.

### What was wrong?

Since the service goes on a schedule at every minute. And the automation used to reset itself after firing a notification, when an error happens the notification will keep firing up for every minutes until fixed. This is insane.

### How does this fix it?

- Changed the automation to not reset the status once the notification is fired.
- Controled the status from the service to only sets the flag if it is not previously set. Setting the flag should fire a notifiction.
- Added a reset method to reset the status from within the service withour firing notifications once the problem is fixed. This ensures the status to allow for firing notifications in future failures.